### PR TITLE
Fix color for required asterisk

### DIFF
--- a/lib/dsfr_form_builder.rb
+++ b/lib/dsfr_form_builder.rb
@@ -54,7 +54,7 @@ module DsfrFormBuilder
     end
 
     def required_tag
-      @template.content_tag(:span, "*", class: "fr-text-error")
+      @template.content_tag(:span, "*", class: "fr-label--error")
     end
 
     def dsfr_error_message(attr)


### PR DESCRIPTION
The DSFR doesn't have a `fr-text-error` class (yet).