### PR TITLE
Support des radio buttons

### DIFF
--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -77,6 +77,42 @@ module Dsfr
       select(attribute, choices, { include_blank: opts[:include_blank] }, class: "fr-select")
     end
 
+    def dsfr_radio_buttons(attribute, choices, legend: nil, hint: nil, **opts, &block)
+      legend_content = @template.safe_join([
+        legend || @object.class.human_attribute_name(attribute),
+        hint ? hint_tag(hint) : nil
+      ].compact)
+      @template.content_tag(:fieldset, class: "fr-fieldset") do
+        @template.safe_join(
+          [
+            @template.content_tag(:legend, legend_content, class: "fr-fieldset__legend--regular fr-fieldset__legend"),
+            choices.map { |c| dsfr_radio_option(attribute, value: c[:value], label_text: c[:label], hint: c[:hint], **opts) },
+            block_given? ? @template.content_tag(:div, class: "fr-fieldset__element", &block) : nil
+          ]
+        )
+      end
+    end
+
+    def dsfr_radio_option(attribute, value:, label_text:, hint:, **opts)
+      @template.content_tag(:div, class: "fr-fieldset__element") do
+        @template.content_tag(:div, class: "fr-radio-group") do
+          @template.safe_join(
+            [
+              radio_button(attribute, value, **opts),
+              label([ attribute, value ].join("_").to_sym) do
+                @template.safe_join(
+                  [
+                    label_text,
+                    hint.present? ? @template.content_tag(:span, hint, class: "fr-hint-text") : nil
+                  ]
+                )
+              end
+            ]
+          )
+        end
+      end
+    end
+
     def dsfr_label_with_hint(attribute, opts = {})
       label_class = "fr-label #{opts[:class]}"
       label(attribute, class: label_class) do

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -77,7 +77,7 @@ module Dsfr
       select(attribute, choices, { include_blank: opts[:include_blank] }, class: "fr-select")
     end
 
-    def dsfr_radio_buttons(attribute, choices, legend: nil, hint: nil, **opts, &block)
+    def dsfr_radio_buttons(attribute, choices, legend: nil, hint: nil, **opts)
       legend_content = @template.safe_join([
         legend || @object.class.human_attribute_name(attribute),
         hint ? hint_tag(hint) : nil
@@ -86,8 +86,7 @@ module Dsfr
         @template.safe_join(
           [
             @template.content_tag(:legend, legend_content, class: "fr-fieldset__legend--regular fr-fieldset__legend"),
-            choices.map { |c| dsfr_radio_option(attribute, value: c[:value], label_text: c[:label], hint: c[:hint], **opts) },
-            block_given? ? @template.content_tag(:div, class: "fr-fieldset__element", &block) : nil
+            choices.map { |c| dsfr_radio_option(attribute, value: c[:value], label_text: c[:label], hint: c[:hint], **opts) }
           ]
         )
       end


### PR DESCRIPTION
repris depuis https://github.com/betagouv/rdv-service-public/pull/4829/files#diff-f873f991433d50353bc192119d5fb530ccc451fb6f280fa15cea9730eededb6b

que j’avais repris et modifié un peu depuis https://github.com/betagouv/aplypro/blob/main/app/helpers/dsfr_form_builder.rb



