### PR TITLE
afficher le diff lorsqu’une spec échoue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem "actionview"
 gem "activemodel"
 gem "nokogiri"
 gem "uri" # necessary on github actions
+gem "diffy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
     connection_pool (2.5.0)
     crass (1.0.6)
     diff-lcs (1.5.1)
+    diffy (3.4.3)
     drb (2.2.1)
     erubi (1.13.1)
     i18n (1.14.7)
@@ -143,6 +144,7 @@ PLATFORMS
 DEPENDENCIES
   actionview
   activemodel
+  diffy
   dsfr-form_builder!
   nokogiri
   rspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,5 +17,6 @@ require 'action_view'
 require 'active_support'
 require 'active_model'
 require 'nokogiri'
+require 'diffy'
 
 Dir[File.expand_path('{../lib/**/*.rb,support/**/*.rb}', __dir__)].sort.each { |f| require f }

--- a/spec/support/matchers/html_matcher.rb
+++ b/spec/support/matchers/html_matcher.rb
@@ -9,28 +9,34 @@ RSpec::Matchers.define :match_html do |expected|
           attr.value = attr.value.strip
         end
       end
+      if node.text?
+        node.content = node.content.strip
+      end
     end
     # remove all whitespaces between tags
     doc.to_s.gsub(/>\s+</, '><')
   end
 
   def beautify_html(html)
-    # cf https://stackoverflow.com/a/7839017
-    Nokogiri::XML(html, &:noblanks).to_s.sub('<?xml version="1.0"?>', '')
+    # Add line breaks after opening and closing tags
+    split = html.gsub(/(<[^>]*>)/, "\\1\n")
+    # now parse html and pretty print it
+    Nokogiri::HTML.fragment(split).to_xhtml(indent: 2)
   end
 
   match do |actual|
-    @actual = actual
-    normalize_html(expected) == normalize_html(actual)
+    @actual_normalized = normalize_html(actual)
+    @expected_normalized = normalize_html(expected)
+    @actual_normalized == @expected_normalized
   end
 
   failure_message do
+    expected_beautified = beautify_html(@expected_normalized)
+    actual_beautified = beautify_html(@actual_normalized)
+    differences = Diffy::Diff.new(expected_beautified, actual_beautified).to_s(:text)
     <<~MSG
-      --- Expected ---
-      #{beautify_html(expected)}
-
-      --- Actual ---
-      #{beautify_html(@actual)}
+      --- Differences ---
+      #{differences}
     MSG
   end
 end

--- a/spec/support/matchers/html_matcher.rb
+++ b/spec/support/matchers/html_matcher.rb
@@ -33,7 +33,7 @@ RSpec::Matchers.define :match_html do |expected|
   failure_message do
     expected_beautified = beautify_html(@expected_normalized)
     actual_beautified = beautify_html(@actual_normalized)
-    differences = Diffy::Diff.new(expected_beautified, actual_beautified).to_s(:text)
+    differences = Diffy::Diff.new(actual_beautified, expected_beautified).to_s(:text)
     <<~MSG
       --- Differences ---
       #{differences}

--- a/spec/support/matchers/html_matcher.rb
+++ b/spec/support/matchers/html_matcher.rb
@@ -18,10 +18,7 @@ RSpec::Matchers.define :match_html do |expected|
   end
 
   def beautify_html(html)
-    # Add line breaks after opening and closing tags
-    split = html.gsub(/(<[^>]*>)/, "\\1\n")
-    # now parse html and pretty print it
-    Nokogiri::HTML.fragment(split).to_xhtml(indent: 2)
+    Nokogiri::HTML.fragment(html).to_xhtml(indent: 2)
   end
 
   match do |actual|


### PR DESCRIPTION
ça ressemble à ça

<img width="1031" alt="image" src="https://github.com/user-attachments/assets/bff9381c-e7ab-4d9f-b1b9-c541f43d7f1a" />
