### PR TITLE
Permettre de pré-cocher un radio button

### DIFF
--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -90,18 +90,18 @@ module Dsfr
         @template.safe_join(
           [
             @template.content_tag(:legend, legend_content, class: "fr-fieldset__legend--regular fr-fieldset__legend"),
-            choices.map { |c| dsfr_radio_option(attribute, value: c[:value], label_text: c[:label], hint: c[:hint], **opts) }
+            choices.map { |c| dsfr_radio_option(attribute, value: c[:value], label_text: c[:label], hint: c[:hint], checked: c[:checked], **opts) }
           ]
         )
       end
     end
 
-    def dsfr_radio_option(attribute, value:, label_text:, hint:, **opts)
+    def dsfr_radio_option(attribute, value:, label_text:, hint:, checked:, **opts)
       @template.content_tag(:div, class: "fr-fieldset__element") do
         @template.content_tag(:div, class: "fr-radio-group") do
           @template.safe_join(
             [
-              radio_button(attribute, value, **opts),
+              radio_button(attribute, value, checked:, **opts),
               label([ attribute, value ].join("_").to_sym) do
                 @template.safe_join(
                   [


### PR DESCRIPTION
Dans certain parcours, nous souhaitons afficher un radio button avec une option pré-cochée.

Cela n’est pas possible à l’heure actuelle. L’objectif de cette PR est de rajouter cette option.