### PR TITLE
Ajout des radio buttons rich

### DIFF
--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -96,9 +96,10 @@ module Dsfr
       end
     end
 
-    def dsfr_radio_option(attribute, value:, label_text:, hint:, **opts)
+    def dsfr_radio_option(attribute, value:, label_text:, hint:, rich: false, **opts)
       @template.content_tag(:div, class: "fr-fieldset__element") do
-        @template.content_tag(:div, class: "fr-radio-group") do
+        classes = rich ? "fr-radio-group fr-radio-rich" : "fr-radio-group"
+        @template.content_tag(:div, class: classes) do
           @template.safe_join(
             [
               radio_button(attribute, value, **opts),

--- a/spec/dsfr-form_builder_spec.rb
+++ b/spec/dsfr-form_builder_spec.rb
@@ -38,13 +38,16 @@ RSpec.describe Dsfr::FormBuilder do
   end
 
   describe "#dsfr_radio_buttons" do
-    it 'generates the correct HTML' do
-      choices = [
+    let(:choices) do
+      [
         { value: "elle", label: "Elle", hint: "« Elle était présente »" },
         { value: "il", label: "Il", hint: "« Il était présent »", checked: true },
         { value: "iel", label: "Iel", hint: "« Iel était présent·e »" }
       ]
-      hint = "Choisissez le pronom qui vous correspond le mieux"
+    end
+    let(:hint) { "Choisissez le pronom qui vous correspond le mieux" }
+
+    it 'generates the correct HTML' do
       expect(builder.dsfr_radio_buttons(:pronom, choices, legend: "Pronom", hint: hint)).to match_html(<<~HTML)
         <fieldset class="fr-fieldset">
           <legend class="fr-fieldset__legend--regular fr-fieldset__legend">
@@ -88,6 +91,54 @@ RSpec.describe Dsfr::FormBuilder do
           </div>
         </fieldset>
       HTML
+    end
+
+    context 'with rich option' do
+      it 'generates the correct HTML' do
+        expect(builder.dsfr_radio_buttons(:pronom, choices, legend: "Pronom", hint: hint, rich: true)).to match_html(<<~HTML)
+        <fieldset class="fr-fieldset">
+          <legend class="fr-fieldset__legend--regular fr-fieldset__legend">
+            Pronom
+            <span class="fr-hint-text">
+              Choisissez le pronom qui vous correspond le mieux
+            </span>
+          </legend>
+          <div class="fr-fieldset__element">
+            <div class="fr-radio-group fr-radio-rich">
+              <input type="radio" value="elle" name="record[pronom]" id="record_pronom_elle">
+              <label for="record_pronom_elle">
+                Elle
+                <span class="fr-hint-text">
+                  « Elle était présente »
+                </span>
+              </label>
+            </div>
+          </div>
+          <div class="fr-fieldset__element">
+            <div class="fr-radio-group fr-radio-rich">
+              <input type="radio" value="il" checked="checked" name="record[pronom]" id="record_pronom_il">
+              <label for="record_pronom_il">
+                Il
+                <span class="fr-hint-text">
+                  « Il était présent »
+                </span>
+              </label>
+            </div>
+          </div>
+          <div class="fr-fieldset__element">
+            <div class="fr-radio-group fr-radio-rich">
+              <input type="radio" value="iel" name="record[pronom]" id="record_pronom_iel">
+              <label for="record_pronom_iel">
+                Iel
+                <span class="fr-hint-text">
+                  « Iel était présent·e »
+                </span>
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      HTML
+      end
     end
   end
 end


### PR DESCRIPTION
Dans cette PR on permet d’utiliser le style rich des radio buttons (sans pictogramme).

https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/bouton-radio-riche