### PR TITLE
Add gemspec metadata

### DIFF
--- a/dsfr-form_builder.gemspec
+++ b/dsfr-form_builder.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.summary     = "Ruby on Rails form builder pour le Système de Design de l'État (DSFR)"
   spec.description = "Cette librairie de composants vise à simplifier la création de formulaire au DSFR (Système de Design de l'État) dans les applications web utilisant Ruby On Rails"
   spec.license     = 'MIT'
+  spec.metadata    = METADATA
 
   spec.files = Dir['lib/**/*']
 


### PR DESCRIPTION
Nous avons un hash de méta données qui n’est aujourd’hui pas utilisé dans le `gemspec`. Les différents liens n’apparaissent donc pas sur la page Rubygems.