### PR TITLE
Fix: correction de l’espace des checkbox

### DIFF
--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -55,13 +55,15 @@ module Dsfr
     end
 
     def dsfr_check_box(attribute, opts = {}, checked_value = "1", unchecked_value = "0")
-      @template.content_tag(:div, class: "fr-checkbox-group") do
-        @template.safe_join(
-          [
-            check_box(attribute, opts, checked_value, unchecked_value),
-            dsfr_label_with_hint(attribute, opts)
-          ]
-        )
+      @template.content_tag(:div, class: "fr-fieldset__element") do
+        @template.content_tag(:div, class: "fr-checkbox-group") do
+          @template.safe_join(
+            [
+              check_box(attribute, opts, checked_value, unchecked_value),
+              dsfr_label_with_hint(attribute, opts)
+            ]
+          )
+        end
       end
     end
 

--- a/spec/dsfr-form_builder_spec.rb
+++ b/spec/dsfr-form_builder_spec.rb
@@ -40,10 +40,12 @@ RSpec.describe Dsfr::FormBuilder do
   describe "#dsfr_check_box" do
     it 'generates the correct HTML' do
       expect(builder.dsfr_check_box(:name)).to match_html(<<~HTML)
-        <div class="fr-checkbox-group">
-          <input name="record[name]" type="hidden" value="0" autocomplete="off">
-          <input type="checkbox" value="1" name="record[name]" id="record_name" />
-          <label class="fr-label" for="record_name">Name</label>
+        <div class="fr-fieldset__element">
+          <div class="fr-checkbox-group">
+            <input name="record[name]" type="hidden" value="0" autocomplete="off">
+            <input type="checkbox" value="1" name="record[name]" id="record_name" />
+            <label class="fr-label" for="record_name">Name</label>
+          </div>
         </div>
       HTML
     end
@@ -51,15 +53,17 @@ RSpec.describe Dsfr::FormBuilder do
     context 'with label and hint personalisation' do
       it 'generates the correct HTML' do
         expect(builder.dsfr_check_box(:name, label: "Nom", hint: "Votre nom")).to match_html(<<~HTML)
-          <div class="fr-checkbox-group">
-            <input name="record[name]" type="hidden" value="0" autocomplete="off">
-            <input label="Nom" hint="Votre nom" type="checkbox" value="1" name="record[name]" id="record_name" />
-            <label class="fr-label" for="record_name">
-              Nom
-              <span class="fr-hint-text">
-                Votre nom
-              </span>
-            </label>
+          <div class="fr-fieldset__element">
+            <div class="fr-checkbox-group">
+              <input name="record[name]" type="hidden" value="0" autocomplete="off">
+              <input label="Nom" hint="Votre nom" type="checkbox" value="1" name="record[name]" id="record_name" />
+              <label class="fr-label" for="record_name">
+                Nom
+                <span class="fr-hint-text">
+                  Votre nom
+                </span>
+              </label>
+            </div>
           </div>
         HTML
       end


### PR DESCRIPTION
Nous nous sommes rendu compte [ici](https://github.com/betagouv/rdv-service-public/pull/5124#pullrequestreview-2667256456) qu’il manquait une div dans notre implémentation des checkbox.

En ajoutant `fr-fieldset__element` on est maintenant iso avec le DSFR.