### PR TITLE
Fix ArgumentError in dsfr_select

### DIFF
--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -125,7 +125,7 @@ module Dsfr
         @template.safe_join(
           [
             dsfr_label_with_hint(attribute, opts),
-            dsfr_select_tag(attribute, choices, **opts, **(input_options)),
+            dsfr_select_tag(attribute, choices, opts.merge(input_options)),
             dsfr_error_message(attribute)
           ]
         )

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -125,7 +125,7 @@ module Dsfr
         @template.safe_join(
           [
             dsfr_label_with_hint(attribute, opts),
-            dsfr_select_tag(attribute, choices, opts.merge(input_options)),
+            dsfr_select_tag(attribute, choices, opts.merge(input_options).except(:hint, :name)),
             dsfr_error_message(attribute)
           ]
         )
@@ -133,7 +133,9 @@ module Dsfr
     end
 
     def dsfr_select_tag(attribute, choices, opts)
-      select(attribute, choices, { include_blank: opts[:include_blank] }, class: "fr-select")
+      opts[:class] = join_classes("fr-select", opts[:class])
+      include_blank = opts.delete(:include_blank)
+      select(attribute, choices, { include_blank: }, **opts)
     end
 
     def dsfr_radio_buttons(attribute, choices, legend: nil, hint: nil, **opts)

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -13,7 +13,7 @@ module Dsfr
 
     def dsfr_button(value, options = {})
       options[:type] ||= :button
-      options[:class] = join_classes([ "fr-btn", options[:class] ])
+      options[:class] = join_classes("fr-btn", options[:class])
       button(value, options)
     end
 
@@ -46,11 +46,11 @@ module Dsfr
     end
 
     def dsfr_input_group(attribute, opts, kind: :input, &block)
-      classes = join_classes([
+      classes = join_classes(
         "fr-#{kind}-group",
         ("fr-#{kind}-group--error" if @object&.errors&.include?(attribute)),
         opts[:class]
-      ])
+      )
       @template.content_tag(:div, class: classes, data: opts[:data]) do
         yield(block)
       end
@@ -194,8 +194,8 @@ module Dsfr
       @template.content_tag(:span, text, class: "fr-hint-text") if text
     end
 
-    def join_classes(arr)
-      arr.compact.join(" ")
+    def join_classes(*arr)
+      Array.wrap(arr).compact.join(" ")
     end
 
     def label_value(attribute, opts)

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -134,8 +134,9 @@ module Dsfr
 
     def dsfr_select_tag(attribute, choices, opts)
       opts[:class] = join_classes("fr-select", opts[:class])
-      include_blank = opts.delete(:include_blank)
-      select(attribute, choices, { include_blank: opts[:include_blank], selected: opts[:selected] }, class: opts[:class])
+      options = opts.slice(:include_blank, :selected, :disabled)
+      html_options = opts.except(:include_blank, :selected, :disabled)
+      select(attribute, choices, options, **html_options)
     end
 
     def dsfr_radio_buttons(attribute, choices, legend: nil, hint: nil, **opts)

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -135,7 +135,7 @@ module Dsfr
     def dsfr_select_tag(attribute, choices, opts)
       opts[:class] = join_classes("fr-select", opts[:class])
       include_blank = opts.delete(:include_blank)
-      select(attribute, choices, { include_blank: }, **opts)
+      select(attribute, choices, { include_blank: opts[:include_blank], selected: opts[:selected] }, class: opts[:class])
     end
 
     def dsfr_radio_buttons(attribute, choices, legend: nil, hint: nil, **opts)

--- a/spec/dsfr-form_builder_spec.rb
+++ b/spec/dsfr-form_builder_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Dsfr::FormBuilder do
   end
 
   describe "#dsfr_select" do
-    let(:choices) { [["Option 1", 1], ["Option 2", 2]] }
+    let(:choices) { [ [ "Option 1", 1 ], [ "Option 2", 2 ] ] }
 
     it "generates the correct HTML" do
       expect(builder.dsfr_select(:pronom, choices)).to match_html(<<~HTML)
@@ -134,10 +134,11 @@ RSpec.describe Dsfr::FormBuilder do
     end
 
     it "supports required, hint and include_blank options" do
-      expect(builder.dsfr_select(:pronom, choices, hint: "Choisissez votre pronom", include_blank: "Choisissez une option")).to match_html(<<~HTML)
+      expect(builder.dsfr_select(:pronom, choices, required: true, hint: "Choisissez votre pronom", include_blank: "Choisissez une option")).to match_html(<<~HTML)
         <div class="fr-select-group">
           <label class="fr-label" for="record_pronom">
             Pronom
+            <span class="fr-text-error">*</span>
             <span class="fr-hint-text">Choisissez votre pronom</span>
           </label>
           <select required="required" class="fr-select" name="record[pronom]" id="record_pronom">

--- a/spec/dsfr-form_builder_spec.rb
+++ b/spec/dsfr-form_builder_spec.rb
@@ -117,6 +117,38 @@ RSpec.describe Dsfr::FormBuilder do
     end
   end
 
+  describe "#dsfr_select" do
+    let(:choices) { [["Option 1", 1], ["Option 2", 2]] }
+
+    it "generates the correct HTML" do
+      expect(builder.dsfr_select(:pronom, choices)).to match_html(<<~HTML)
+        <div class="fr-select-group">
+          <label class="fr-label" for="record_pronom">Pronom</label>
+          <select class="fr-select" name="record[pronom]" id="record_pronom">
+            <option value="1">Option 1</option>
+            <option value="2">Option 2</option>
+          </select>
+        </div>
+      HTML
+    end
+
+    it "supports required, hint and include_blank options" do
+      expect(builder.dsfr_select(:pronom, choices, hint: "Choisissez votre pronom", include_blank: "Choisissez une option")).to match_html(<<~HTML)
+        <div class="fr-select-group">
+          <label class="fr-label" for="record_pronom">
+            Pronom
+            <span class="fr-hint-text">Choisissez votre pronom</span>
+          </label>
+          <select required="required" class="fr-select" name="record[pronom]" id="record_pronom">
+            <option value="">Choisissez une option</option>
+            <option value="1">Option 1</option>
+            <option value="2">Option 2</option>
+          </select>
+        </div>
+      HTML
+    end
+  end
+
   describe "#dsfr_check_box" do
     it 'generates the correct HTML' do
       expect(builder.dsfr_check_box(:name)).to match_html(<<~HTML)

--- a/spec/dsfr-form_builder_spec.rb
+++ b/spec/dsfr-form_builder_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 class TestHelper
   include ActionView::Helpers::FormHelper
   include ActionView::Helpers::FormTagHelper
+  include ActionView::Helpers::FormOptionsHelper
 end
 
 class Record


### PR DESCRIPTION
Fixes #40

J'ai également corrigé une inexactitude (la classe d'erreur n'était pas appliquée), et simplifié l'utilisation de `join_classes`, qui accepte désormais un array ou des items individuels grâce au helper [`Array.wrap`](https://apidock.com/rails/v7.1.3.2/Array/wrap/class).