### PR TITLE
Allow using inputs in `form_with` when model is nil

### DIFF
--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -147,7 +147,7 @@ module Dsfr
     end
 
     def dsfr_error_message(attr)
-      return if @object.errors[attr].none?
+      return if @object.nil? || @object.errors[attr].none?
 
       @template.content_tag(:p, class: "fr-messages-group") do
         safe_join(@object.errors.full_messages_for(attr).map do |msg|
@@ -174,7 +174,7 @@ module Dsfr
       join_classes(
         [
           "fr-input-group",
-          @object.errors[attribute].any? ? "fr-input-group--error" : nil,
+          @object && @object.errors[attribute].any? ? "fr-input-group--error" : nil,
           opts[:class]
         ]
       )
@@ -184,7 +184,7 @@ module Dsfr
       join_classes(
         [
           "fr-upload-group",
-          @object.errors[attribute].any? ? "fr-upload-group--error" : nil,
+          @object && @object.errors[attribute].any? ? "fr-upload-group--error" : nil,
           opts[:class]
         ]
       )

--- a/spec/dsfr-form_builder_spec.rb
+++ b/spec/dsfr-form_builder_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe Dsfr::FormBuilder do
         </div>
       HTML
     end
+
+    context 'when object is nil' do
+      let(:object) { nil }
+
+      it "doesn't raise" do
+        expect { builder.dsfr_text_field(:name, label: "Label") }.not_to raise_error
+      end
+    end
   end
 
   describe '#dsfr_text_area' do
@@ -34,6 +42,14 @@ RSpec.describe Dsfr::FormBuilder do
           <textarea class="fr-input" name="record[name]" id="record_name">Jean Paul</textarea>
         </div>
       HTML
+    end
+
+    context 'when object is nil' do
+      let(:object) { nil }
+
+      it "doesn't raise" do
+        expect { builder.dsfr_text_area(:name, label: "Label") }.not_to raise_error
+      end
     end
   end
 
@@ -58,6 +74,14 @@ RSpec.describe Dsfr::FormBuilder do
           <input class="fr-upload" required="required" type="file" name="record[name]" id="record_name" />
         </div>
       HTML
+    end
+
+    context 'when object is nil' do
+      let(:object) { nil }
+
+      it "doesn't raise" do
+        expect { builder.dsfr_file_field(:name, label: "Label") }.not_to raise_error
+      end
     end
   end
 
@@ -90,6 +114,14 @@ RSpec.describe Dsfr::FormBuilder do
             </div>
           </div>
         HTML
+      end
+    end
+
+    context 'when object is nil' do
+      let(:object) { nil }
+
+      it "doesn't raise" do
+        expect { builder.dsfr_check_box(:name, label: "Label") }.not_to raise_error
       end
     end
   end
@@ -195,6 +227,14 @@ RSpec.describe Dsfr::FormBuilder do
             </div>
           </fieldset>
         HTML
+      end
+    end
+
+    context 'when object is nil' do
+      let(:object) { nil }
+
+      it "doesn't raise" do
+        expect { builder.dsfr_radio_buttons(:pronom, choices, legend: "Legend", label_text: "Label") }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
```ruby
form_with(url: search_path) do |f|
  f.dsfr_text_field :query, label: "Votre recherche"
  f.dsfr_check_box :case_insensitive, label: "Ignorer la casse"
  f.submit "Rechercher"
end

# Before: 💥
NoMethodError undefined method 'errors' for nil
# After: 👌
```