### PR TITLE
fix: Improve check_box helper

### DIFF
--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -70,7 +70,7 @@ module Dsfr
       @template.content_tag(:div, class: "fr-fieldset__element #{'fr-fieldset__element--inline' if opts.delete(:inline)}") do
         @template.content_tag(:div, class: "fr-checkbox-group") do
           @template.safe_join([
-            check_box(attribute, opts, checked_value, unchecked_value),
+            check_box(attribute, opts.except(:label, :hint), checked_value, unchecked_value),
             dsfr_label_with_hint(attribute, opts)
           ])
         end

--- a/spec/dsfr-form_builder_spec.rb
+++ b/spec/dsfr-form_builder_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Dsfr::FormBuilder do
           <div class="fr-fieldset__element fr-fieldset__element--inline">
             <div class="fr-checkbox-group">
               <input name="record[name]" type="hidden" value="unchecked" autocomplete="off">
-              <input label="Nom" hint="Votre nom" type="checkbox" value="checked" name="record[name]" id="record_name" />
+              <input type="checkbox" value="checked" name="record[name]" id="record_name" />
               <label class="fr-label" for="record_name">
                 Nom
                 <span class="fr-hint-text">


### PR DESCRIPTION
- [x] Test de toutes les options du helper `dsfr_check_box`
- [x] Empêche les options du helper de finir en attributs de la check box
- [x] Ajout de l'option `inline`