### PR TITLE
test: Setup Rspec to record test status (except on CI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.gem
 coverage
+spec/examples.txt

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.disable_monkey_patching!
   config.warnings = true
+  config.example_status_persistence_file_path = "spec/examples.txt" unless ENV.key?("CI")
 end
 
 require 'uri' # necessary on github actions


### PR DESCRIPTION
Allows using `--only-failure` and `--next-failure`.