### PR TITLE
feat: Use dsfr_label_with_hint in dsfr_radio_buttons

### DIFF
--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -158,14 +158,7 @@ module Dsfr
           @template.safe_join(
             [
               radio_button(attribute, value, checked:, **opts),
-              label([ attribute, value ].join("_").to_sym) do
-                @template.safe_join(
-                  [
-                    label_text,
-                    hint_tag(hint)
-                  ]
-                )
-              end
+              dsfr_label_with_hint(attribute, opts.merge(label_text: label_text, hint: hint, value: value))
             ]
           )
         end

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -175,7 +175,7 @@ module Dsfr
     def dsfr_label_with_hint(attribute, opts = {})
       label_class = "fr-label #{opts[:class]}"
       label(attribute, class: label_class, value: opts[:value]) do
-        label_and_tags = [ label_value(attribute, opts) ]
+        label_and_tags = [ opts[:label_text] || label_value(attribute, opts) ]
         label_and_tags.push(required_tag) if opts[:required] && display_required_tags
         label_and_tags.push(hint_tag(opts[:hint])) if opts[:hint]
 

--- a/spec/dsfr-form_builder_spec.rb
+++ b/spec/dsfr-form_builder_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe Dsfr::FormBuilder do
           <div class="fr-fieldset__element">
             <div class="fr-radio-group">
               <input type="radio" value="elle", checked="checked", name="record[pronom]" id="record_pronom_elle">
-              <label for="record_pronom_elle">
+              <label class="fr-label" for="record_pronom_elle">
                 Elle
                 <span class="fr-hint-text">
                   « Elle était présente »
@@ -256,7 +256,7 @@ RSpec.describe Dsfr::FormBuilder do
           <div class="fr-fieldset__element">
             <div class="fr-radio-group">
               <input type="radio" value="il" name="record[pronom]" id="record_pronom_il">
-              <label for="record_pronom_il">
+              <label class="fr-label" for="record_pronom_il">
                 Il
                 <span class="fr-hint-text">
                   « Il était présent »
@@ -267,7 +267,7 @@ RSpec.describe Dsfr::FormBuilder do
           <div class="fr-fieldset__element">
             <div class="fr-radio-group">
               <input type="radio" value="iel" name="record[pronom]" id="record_pronom_iel">
-              <label for="record_pronom_iel">
+              <label class="fr-label" for="record_pronom_iel">
                 Iel
                 <span class="fr-hint-text">
                   « Iel était présent·e »
@@ -292,7 +292,7 @@ RSpec.describe Dsfr::FormBuilder do
             <div class="fr-fieldset__element">
               <div class="fr-radio-group fr-radio-rich">
                 <input type="radio" value="elle" checked="checked" name="record[pronom]" id="record_pronom_elle">
-                <label for="record_pronom_elle">
+                <label class="fr-label" for="record_pronom_elle">
                   Elle
                   <span class="fr-hint-text">
                     « Elle était présente »
@@ -303,7 +303,7 @@ RSpec.describe Dsfr::FormBuilder do
             <div class="fr-fieldset__element">
               <div class="fr-radio-group fr-radio-rich">
                 <input type="radio" value="il" name="record[pronom]" id="record_pronom_il">
-                <label for="record_pronom_il">
+                <label class="fr-label" for="record_pronom_il">
                   Il
                   <span class="fr-hint-text">
                     « Il était présent »
@@ -314,7 +314,7 @@ RSpec.describe Dsfr::FormBuilder do
             <div class="fr-fieldset__element">
               <div class="fr-radio-group fr-radio-rich">
                 <input type="radio" value="iel" name="record[pronom]" id="record_pronom_iel">
-                <label for="record_pronom_iel">
+                <label class="fr-label" for="record_pronom_iel">
                   Iel
                   <span class="fr-hint-text">
                     « Iel était présent·e »


### PR DESCRIPTION
Note : les labels des boutons radio ont désormais la classe `fr-label` (comme c'est requis par le DSFR).

Il faudrait ajouter la gestion d'erreurs, dans un autre temps.