### PR TITLE
Using class_names, tag_helper and define_method

### DIFF
--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -21,31 +21,15 @@ module Dsfr
     end
 
     def dsfr_submit(value, options = {})
-      dsfr_button(value, options.merge(type: :submit))
+      options[:type] = :submit
+
+      dsfr_button(value, options)
     end
 
-    def dsfr_text_field(attribute, opts = {})
-      dsfr_input_field(attribute, :text_field, opts)
-    end
-
-    def dsfr_text_area(attribute, opts = {})
-      dsfr_input_field(attribute, :text_area, opts)
-    end
-
-    def dsfr_email_field(attribute, opts = {})
-      dsfr_input_field(attribute, :email_field, opts)
-    end
-
-    def dsfr_url_field(attribute, opts = {})
-      dsfr_input_field(attribute, :url_field, opts)
-    end
-
-    def dsfr_phone_field(attribute, opts = {})
-      dsfr_input_field(attribute, :phone_field, opts)
-    end
-
-    def dsfr_number_field(attribute, opts = {})
-      dsfr_input_field(attribute, :number_field, opts)
+    %i[text_field text_area email_field url_field phone_field number_field].each do |field_type|
+      define_method("dsfr_#{field_type}") do |attribute, **options|
+        dsfr_input_field(attribute, field_type, **options)
+      end
     end
 
     def dsfr_input_group(attribute, opts, kind: :input, &block)


### PR DESCRIPTION
In this PR:

- Replacing `content_tag(:x)` with the new modern syntax `tag.x` for better readability 
- Using the built-in `class_names` helper to generate the classes. See: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-token_list
- Cleaning the code a bit
- Using `define_method` to generate the methods for basic fields like `text_field` or `url_field`

Feel free to update the PR if needed 👍 