### PR TITLE
refactor: Various improvements by guillaumebriday

### DIFF
--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -18,7 +18,8 @@ module Dsfr
     end
 
     def dsfr_submit(value, options = {})
-      dsfr_button(value, options.merge(type: :submit))
+      options[:type] = :submit
+      dsfr_button(value, options)
     end
 
     %i[text_field text_area email_field url_field phone_field number_field].each do |field_type|

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -33,7 +33,7 @@ module Dsfr
         opts[:class],
         "fr-#{kind}-group--error" => @object&.errors&.include?(attribute)
       )
-      @template.content_tag(:div, class: classes, data: opts[:data]) do
+      @template.tag.div(class: classes, data: opts[:data]) do
         yield(block)
       end
     end
@@ -59,7 +59,7 @@ module Dsfr
     end
 
     def dsfr_check_box(attribute, opts = {}, checked_value = "1", unchecked_value = "0")
-      @template.content_tag(:div, class: @template.class_names("fr-fieldset__element", "fr-fieldset__element--inline" => opts.delete(:inline))) do
+      @template.tag.div(class: @template.class_names("fr-fieldset__element", "fr-fieldset__element--inline" => opts.delete(:inline))) do
         dsfr_input_group(attribute, opts, kind: :checkbox) do
           @template.safe_join([
             check_box(attribute, opts.except(:label, :hint), checked_value, unchecked_value),
@@ -77,9 +77,9 @@ module Dsfr
       legend = @template.safe_join([ legend, hint_tag(opts.delete(:hint)) ])
       name = opts.delete(:name) || "#{@object_name}[#{method}][]"
       html_options[:class] = @template.class_names("fr-fieldset", html_options[:class])
-      @template.content_tag(:fieldset, **html_options) do
+      @template.tag.fieldset(**html_options) do
         @template.safe_join([
-          @template.content_tag(:legend, legend, class: "fr-fieldset__legend--regular fr-fieldset__legend"),
+          @template.tag.legend(legend, class: "fr-fieldset__legend--regular fr-fieldset__legend"),
           @template.hidden_field_tag(name, "", id: nil),
           collection.map do |item|
             value = item.send(value_method)
@@ -120,17 +120,17 @@ module Dsfr
         legend || @object.class.human_attribute_name(attribute),
         hint_tag(hint)
       ])
-      @template.content_tag(:fieldset, class: "fr-fieldset") do
+      @template.tag.fieldset(class: "fr-fieldset") do
         @template.safe_join([
-          @template.content_tag(:legend, legend_content, class: "fr-fieldset__legend--regular fr-fieldset__legend"),
+          @template.tag.legend(legend_content, class: "fr-fieldset__legend--regular fr-fieldset__legend"),
           choices.map { |c| dsfr_radio_option(attribute, value: c[:value], label_text: c[:label], hint: c[:hint], checked: c[:checked], **opts) }
         ])
       end
     end
 
     def dsfr_radio_option(attribute, value:, label_text:, hint:, checked:, rich: false, **opts)
-      @template.content_tag(:div, class: "fr-fieldset__element") do
-        @template.content_tag(:div, class: @template.class_names("fr-radio-group", "fr-radio-rich" => rich)) do
+      @template.tag.div(class: "fr-fieldset__element") do
+        @template.tag.div(class: @template.class_names("fr-radio-group", "fr-radio-rich" => rich)) do
           @template.safe_join([
             radio_button(attribute, value, checked:, **opts),
             dsfr_label_with_hint(attribute, opts.merge(label_text: label_text, hint: hint, value: value))
@@ -150,21 +150,21 @@ module Dsfr
     end
 
     def required_tag
-      @template.content_tag(:span, "*", class: "fr-text-error")
+      @template.tag.span("*", class: "fr-text-error")
     end
 
     def dsfr_error_message(attr)
       return if @object.nil? || @object.errors[attr].none?
 
-      @template.content_tag(:p, class: "fr-messages-group") do
+      @template.tag.p(class: "fr-messages-group") do
         safe_join(@object.errors.full_messages_for(attr).map do |msg|
-          @template.content_tag(:span, msg, class: "fr-message fr-message--error")
+          @template.tag.span(msg, class: "fr-message fr-message--error")
         end)
       end
     end
 
     def hint_tag(text)
-      @template.content_tag(:span, text, class: "fr-hint-text") if text
+      @template.tag.span(text, class: "fr-hint-text") if text
     end
 
     def label_value(attribute, opts)

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -28,14 +28,15 @@ module Dsfr
     end
 
     def dsfr_input_group(attribute, opts, kind: :input, &block)
-      classes = @template.class_names(
-        "fr-#{kind}-group",
-        opts[:class],
-        "fr-#{kind}-group--error" => @object&.errors&.include?(attribute)
+      @template.tag.div(
+        yield(block),
+        data: opts[:data],
+        class: @template.class_names(
+               "fr-#{kind}-group",
+               opts[:class],
+               "fr-#{kind}-group--error" => @object&.errors&.include?(attribute)
+        )
       )
-      @template.tag.div(class: classes, data: opts[:data]) do
-        yield(block)
-      end
     end
 
     def dsfr_input_field(attribute, input_kind, opts = {})
@@ -123,7 +124,16 @@ module Dsfr
       @template.tag.fieldset(class: "fr-fieldset") do
         @template.safe_join([
           @template.tag.legend(legend_content, class: "fr-fieldset__legend--regular fr-fieldset__legend"),
-          choices.map { |c| dsfr_radio_option(attribute, value: c[:value], label_text: c[:label], hint: c[:hint], checked: c[:checked], **opts) }
+          choices.map do |choice|
+            dsfr_radio_option(
+              attribute,
+              value: choice[:value],
+              label_text: choice[:label],
+              hint: choice[:hint],
+              checked: choice[:checked],
+              **opts
+            )
+          end
         ])
       end
     end

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -21,28 +21,10 @@ module Dsfr
       dsfr_button(value, options.merge(type: :submit))
     end
 
-    def dsfr_text_field(attribute, opts = {})
-      dsfr_input_field(attribute, :text_field, opts)
-    end
-
-    def dsfr_text_area(attribute, opts = {})
-      dsfr_input_field(attribute, :text_area, opts)
-    end
-
-    def dsfr_email_field(attribute, opts = {})
-      dsfr_input_field(attribute, :email_field, opts)
-    end
-
-    def dsfr_url_field(attribute, opts = {})
-      dsfr_input_field(attribute, :url_field, opts)
-    end
-
-    def dsfr_phone_field(attribute, opts = {})
-      dsfr_input_field(attribute, :phone_field, opts)
-    end
-
-    def dsfr_number_field(attribute, opts = {})
-      dsfr_input_field(attribute, :number_field, opts)
+    %i[text_field text_area email_field url_field phone_field number_field].each do |field_type|
+      define_method("dsfr_#{field_type}") do |attribute, **options|
+        dsfr_input_field(attribute, field_type, **options)
+      end
     end
 
     def dsfr_input_group(attribute, opts, kind: :input, &block)

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -40,25 +40,21 @@ module Dsfr
 
     def dsfr_input_field(attribute, input_kind, opts = {})
       dsfr_input_group(attribute, opts) do
-        @template.safe_join(
-          [
-            dsfr_label_with_hint(attribute, opts),
-            public_send(input_kind, attribute, class: "fr-input", **opts.except(:class, :hint, :label, :data)),
-            dsfr_error_message(attribute)
-          ]
-        )
+        @template.safe_join([
+          dsfr_label_with_hint(attribute, opts),
+          public_send(input_kind, attribute, class: "fr-input", **opts.except(:class, :hint, :label, :data)),
+          dsfr_error_message(attribute)
+        ])
       end
     end
 
     def dsfr_file_field(attribute, opts = {})
       dsfr_input_group(attribute, opts, kind: :upload) do
-        @template.safe_join(
-          [
-            dsfr_label_with_hint(attribute, opts.except(:class)),
-            file_field(attribute, class: "fr-upload", **opts.except(:class, :hint, :label, :data)),
-            dsfr_error_message(attribute)
-          ].compact
-        )
+        @template.safe_join([
+          dsfr_label_with_hint(attribute, opts.except(:class)),
+          file_field(attribute, class: "fr-upload", **opts.except(:class, :hint, :label, :data)),
+          dsfr_error_message(attribute)
+        ])
       end
     end
 
@@ -104,13 +100,11 @@ module Dsfr
 
     def dsfr_select(attribute, choices, input_options: {}, **opts)
       dsfr_input_group(attribute, opts, kind: :select) do
-        @template.safe_join(
-          [
-            dsfr_label_with_hint(attribute, opts),
-            dsfr_select_tag(attribute, choices, opts.merge(input_options).except(:hint, :name)),
-            dsfr_error_message(attribute)
-          ]
-        )
+        @template.safe_join([
+          dsfr_label_with_hint(attribute, opts),
+          dsfr_select_tag(attribute, choices, opts.merge(input_options).except(:hint, :name)),
+          dsfr_error_message(attribute)
+        ])
       end
     end
 
@@ -127,24 +121,20 @@ module Dsfr
         hint_tag(hint)
       ])
       @template.content_tag(:fieldset, class: "fr-fieldset") do
-        @template.safe_join(
-          [
-            @template.content_tag(:legend, legend_content, class: "fr-fieldset__legend--regular fr-fieldset__legend"),
-            choices.map { |c| dsfr_radio_option(attribute, value: c[:value], label_text: c[:label], hint: c[:hint], checked: c[:checked], **opts) }
-          ]
-        )
+        @template.safe_join([
+          @template.content_tag(:legend, legend_content, class: "fr-fieldset__legend--regular fr-fieldset__legend"),
+          choices.map { |c| dsfr_radio_option(attribute, value: c[:value], label_text: c[:label], hint: c[:hint], checked: c[:checked], **opts) }
+        ])
       end
     end
 
     def dsfr_radio_option(attribute, value:, label_text:, hint:, checked:, rich: false, **opts)
       @template.content_tag(:div, class: "fr-fieldset__element") do
         @template.content_tag(:div, class: @template.class_names("fr-radio-group", "fr-radio-rich" => rich)) do
-          @template.safe_join(
-            [
-              radio_button(attribute, value, checked:, **opts),
-              dsfr_label_with_hint(attribute, opts.merge(label_text: label_text, hint: hint, value: value))
-            ]
-          )
+          @template.safe_join([
+            radio_button(attribute, value, checked:, **opts),
+            dsfr_label_with_hint(attribute, opts.merge(label_text: label_text, hint: hint, value: value))
+          ])
         end
       end
     end

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -152,11 +152,11 @@ module Dsfr
 
     def dsfr_label_with_hint(attribute, opts = {})
       label(attribute, class: @template.class_names("fr-label", opts[:class]), value: opts[:value]) do
-        label_and_tags = [ opts[:label_text] || label_value(attribute, opts) ]
-        label_and_tags.push(required_tag) if opts[:required] && display_required_tags
-        label_and_tags.push(hint_tag(opts[:hint])) if opts[:hint]
-
-        @template.safe_join(label_and_tags)
+        @template.safe_join([
+          opts[:label_text] || label_value(attribute, opts),
+          (required_tag if opts[:required] && display_required_tags),
+          (hint_tag(opts[:hint]) if opts[:hint])
+        ])
       end
     end
 


### PR DESCRIPTION
Based on PR #50 by @guillaumebriday

- [x] Use `class_names` instead of custom `join_classes`
- [x] Use `tag.x` instead of `content_tag`
- [x] Replace repetitive methods with `define_method`
- [x] Improve readability and performance