### PR TITLE
feat: Allow passing a block to dsfr_button and dsfr_submit

### DIFF
--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -11,13 +11,21 @@ module Dsfr
       self.display_required_tags = options.fetch(:display_required_tags, true)
     end
 
-    def dsfr_button(value, options = {})
+    def dsfr_button(value = nil, options = {}, &block)
+      if block_given?
+        options = value || {}
+        value = @template.capture { yield(value) }
+      end
       options[:type] ||= :button
       options[:class] = @template.class_names("fr-btn", options[:class])
       button(value, options)
     end
 
-    def dsfr_submit(value, options = {})
+    def dsfr_submit(value = nil, options = {}, &block)
+      if block_given?
+        options = value || {}
+        value = @template.capture { yield(value) }
+      end
       options[:type] = :submit
       dsfr_button(value, options)
     end
@@ -33,9 +41,9 @@ module Dsfr
         yield(block),
         data: opts[:data],
         class: @template.class_names(
-               "fr-#{kind}-group",
-               opts[:class],
-               "fr-#{kind}-group--error" => @object&.errors&.include?(attribute)
+              "fr-#{kind}-group",
+              opts[:class],
+              "fr-#{kind}-group--error" => @object&.errors&.include?(attribute)
         )
       )
     end

--- a/spec/dsfr-form_builder_spec.rb
+++ b/spec/dsfr-form_builder_spec.rb
@@ -30,6 +30,22 @@ RSpec.describe Dsfr::FormBuilder do
         HTML
       end
     end
+
+    context 'when called with a block' do
+      it 'generates the correct HTML' do
+        result = builder.dsfr_button { "Block Content" }
+        expect(result).to match_html(<<~HTML.strip)
+          <button name="button" type="button" class="fr-btn">Block Content</button>
+        HTML
+      end
+
+      it 'accepts options when called with a block' do
+        result = builder.dsfr_button(class: "extra-class", data: { controller: :rails }) { "Block Content" }
+        expect(result).to match_html(<<~HTML.strip)
+          <button name="button" type="button" class="fr-btn extra-class" data-controller="rails">Block Content</button>
+        HTML
+      end
+    end
   end
 
   describe '#dsfr_submit' do
@@ -43,6 +59,22 @@ RSpec.describe Dsfr::FormBuilder do
       it 'generates the correct HTML' do
         expect(builder.dsfr_submit("Submit", name: nil, class: "extra-class", data: { controller: :rails }, aria: { busy: true })).to match_html(<<~HTML.strip)
           <button type="submit" class="fr-btn extra-class" data-controller="rails" aria-busy="true">Submit</button>
+        HTML
+      end
+    end
+
+    context 'when called with a block' do
+      it 'generates the correct HTML' do
+        result = builder.dsfr_submit { "Block Submit" }
+        expect(result).to match_html(<<~HTML.strip)
+          <button name="button" type="submit" class="fr-btn">Block Submit</button>
+        HTML
+      end
+
+      it 'accepts options when called with a block' do
+        result = builder.dsfr_submit(class: "extra-class", data: { controller: :rails }) { "Block Submit" }
+        expect(result).to match_html(<<~HTML.strip)
+          <button name="button" type="submit" class="fr-btn extra-class" data-controller="rails">Block Submit</button>
         HTML
       end
     end


### PR DESCRIPTION
La méthode `button` de Rails accepte un bloc, autant garder la même signature.