### PR TITLE
ajout d'un script et d'instructions pour le déploiement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+deploy_gem:
+	bundle exec ruby scripts/deploy_gem.rb $$VERSION

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ Vous pouvez également spécifier le builder par défaut dans votre fichier `app
 config.action_view.default_form_builder = Dsfr::FormBuilder
 ```
 
+## Déploiement d'une nouvelle version (release process)
+
+Pour déployer une nouvelle version de la gem :
+
+```sh
+VERSION=0.0.10 make deploy_gem
+```
+
+Cela va :
+- modifier le numéro de version dans le code
+- créer un commit et un tag git
+- push sur GitHub
+- créer une release sur GitHub
+- suggérer de créer une release sur Rubygems
+
+
 ## Licence
 
 Le code source et la gem sont distribués sous licence [MIT](https://github.com/betagouv/dsfr-form-builder/blob/main/LICENSE).

--- a/scripts/deploy_gem.rb
+++ b/scripts/deploy_gem.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+
+match_data = ARGV[0].match(/([0-9]+\.[0-9]+\.[0-9]+)/)
+raise ArgumentError, "misformed version, should look like '0.0.13' (no v)" unless match_data
+
+version = match_data[1]
+
+current_git_branch = `git rev-parse --abbrev-ref HEAD`.strip
+raise StandardError, "you need to be on main branch" if current_git_branch != "main"
+
+raise StandardError, "your branch needs to be clean, no changes" unless `git status --porcelain`.empty?
+
+
+commands = <<~BASH.split("\n")
+  sed -E -i '' "s/[0-9]+.[0-9]+.[0-9]+/#{version}/" dsfr-form_builder.gemspec
+  bundle
+  git add dsfr-form_builder.gemspec Gemfile.lock
+  git commit -m "release version #{version}"
+  gem build dsfr-view-components.gemspec
+  git tag -a "#{version}" -m "release version #{version}"
+  git push
+  git push origin "#{version}"
+  gh release create "#{version}" --verify-tag --generate-notes
+BASH
+
+commands.each do |command|
+  puts command
+  res = system(command)
+  raise Exception, "command failed!" unless res
+
+  puts
+end
+
+puts "\n🚀 Almost done!"
+puts "last step is to run this command with a valid 2FA OTP token for your rubygems account:"
+puts "gem push dsfr-form_builder-#{version}.gem --otp 123456"


### PR DESCRIPTION
copié et adapté depuis https://github.com/betagouv/dsfr-view-components/ 

la petite diff c'est que dans ce repo on n'a pas mis de `v` en préfixe des versions sur les tags git et releases GH