### PR TITLE
Retour en arrière sur la signature de dsfr_input_group

### DIFF
--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -36,7 +36,7 @@ module Dsfr
       end
     end
 
-    def dsfr_input_group(attribute, opts, kind: :input, &block)
+    def dsfr_input_group(attribute, kind: :input, **opts, &block)
       @template.tag.div(
         yield(block),
         data: opts[:data],
@@ -49,7 +49,7 @@ module Dsfr
     end
 
     def dsfr_input_field(attribute, input_kind, opts = {})
-      dsfr_input_group(attribute, opts) do
+      dsfr_input_group(attribute, **opts) do
         @template.safe_join([
           dsfr_label_with_hint(attribute, opts),
           public_send(input_kind, attribute, class: "fr-input", **opts.except(:class, :hint, :label, :data)),
@@ -59,7 +59,7 @@ module Dsfr
     end
 
     def dsfr_file_field(attribute, opts = {})
-      dsfr_input_group(attribute, opts, kind: :upload) do
+      dsfr_input_group(attribute, **opts, kind: :upload) do
         @template.safe_join([
           dsfr_label_with_hint(attribute, opts.except(:class)),
           file_field(attribute, class: "fr-upload", **opts.except(:class, :hint, :label, :data)),
@@ -70,7 +70,7 @@ module Dsfr
 
     def dsfr_check_box(attribute, opts = {}, checked_value = "1", unchecked_value = "0")
       @template.tag.div(class: @template.class_names("fr-fieldset__element", "fr-fieldset__element--inline" => opts.delete(:inline))) do
-        dsfr_input_group(attribute, opts, kind: :checkbox) do
+        dsfr_input_group(attribute, **opts, kind: :checkbox) do
           @template.safe_join([
             check_box(attribute, opts.except(:label, :hint), checked_value, unchecked_value),
             dsfr_label_with_hint(attribute, opts)
@@ -109,7 +109,7 @@ module Dsfr
     end
 
     def dsfr_select(attribute, choices, input_options: {}, **opts)
-      dsfr_input_group(attribute, opts, kind: :select) do
+      dsfr_input_group(attribute, **opts, kind: :select) do
         @template.safe_join([
           dsfr_label_with_hint(attribute, opts),
           dsfr_select_tag(attribute, choices, opts.merge(input_options).except(:hint, :name)),


### PR DESCRIPTION
dans https://github.com/betagouv/dsfr-form-builder/pull/47 @goulvench a un peu modifié `dsfr_input_group` pour générer des classes différentes par catégories d'inputs.

Au passage, la signature a changé : 
```rb 
def dsfr_input_group(attribute, opts, &block)
```

est devenu 

```rb
def dsfr_input_group(attribute, opts, kind: :input, &block)
``` 

chez RDVSP on appelait déjà `dsfr_input_group(name, class: "fr-password fr-mt-2w")` 

ce changement casse la retro-compatibilité : ça nous dit maintenant qu'il manque un argument (le `opts`). 

Dans cette PR je propose de rétablir la retro compatibilité. Je transforme la définition en : 

```rb
def dsfr_input_group(attribute, kind: :input, **opts, &block)
```

on peut alors appeler indifférement

```rb
dsfr_input_group("inputname")
dsfr_input_group("inputname", class: "blink-strong")
dsfr_input_group("inputname", class: "blink-strong", kind: :checkbox)
dsfr_input_group("inputname", kind: :checkbox)
```

si je ne dis pas de bêtise. 

En revanche jusque là on n'utilisait pas le _rest operator_ avec les ** je ne sais pas si c'était dans un souci de compatibilité avec des versions de ruby précédentes ?