### PR TITLE
Correctif du passage d'options aux champs input textuels

### DIFF
--- a/docs/views/helpers/text_field.slim
+++ b/docs/views/helpers/text_field.slim
@@ -134,7 +134,7 @@ section.fr-my-4w id="data"
   h2 Avec attributs data
   ruby:
     rb_code = <<~RUBY
-      f.dsfr_text_field :name, data: { controller: "autocomplete", action: "input->autocomplete#search" }
+      f.dsfr_text_field :name, data: { controller: "autocomplete", action: "autocomplete#search" }
     RUBY
   == example(rb_code, "data")
 

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -50,10 +50,10 @@ module Dsfr
     end
 
     def dsfr_input_field(attribute, input_kind, opts = {})
-      dsfr_input_group(attribute, **opts) do
+      dsfr_input_group(attribute, **opts.except(:data)) do
         @template.safe_join([
           dsfr_label_with_hint(attribute, opts.except(:value)),
-          public_send(input_kind, attribute, class: "fr-input", **opts.except(:class, :hint, :label, :data)),
+          public_send(input_kind, attribute, class: "fr-input", **opts.except(:class, :hint, :label)),
           dsfr_error_message(attribute)
         ])
       end

--- a/spec/dsfr-form_builder_spec.rb
+++ b/spec/dsfr-form_builder_spec.rb
@@ -130,6 +130,17 @@ RSpec.describe Dsfr::FormBuilder do
         expect { builder.dsfr_text_field(:name, label: "Label") }.not_to raise_error
       end
     end
+
+    context 'when data attributes are passed' do
+      it 'passes data attributes to the input, not the wrapper div' do
+        expect(builder.dsfr_text_field(:name, data: { controller: "foo" })).to match_html(<<~HTML)
+          <div class="fr-input-group">
+            <label class="fr-label" for="record_name">Name</label>
+            <input class="fr-input" data-controller="foo" type="text" value="Jean Paul" name="record[name]" id="record_name" />
+          </div>
+        HTML
+      end
+    end
   end
 
   describe '#dsfr_text_area' do


### PR DESCRIPTION
data était passé au wrapper plutôt qu’à l'input 🤦 