### PR TITLE
Corriger la cohérence du passage de classes CSS via `class:` 

### DIFF
--- a/docs/views/helpers/check_box.slim
+++ b/docs/views/helpers/check_box.slim
@@ -78,6 +78,18 @@ section.fr-my-4w id="options-disponibles"
           td 3ème argument
           td String
           td Valeur quand non coché (défaut: "0")
+        tr
+          td: code data:
+          td Hash
+          td Attributs data-* pour la case à cocher
+        tr
+          td: code class:
+          td String
+          td Classes CSS additionnelles pour la case à cocher
+        tr
+          td: code group_class:
+          td String
+          td Classes CSS additionnelles pour le groupe
 
 section.fr-my-4w id="label-personnalise"
   h2 Avec un label personnalisé

--- a/docs/views/helpers/file_field.slim
+++ b/docs/views/helpers/file_field.slim
@@ -74,6 +74,18 @@ section.fr-my-4w id="options-disponibles"
           td: code multiple:
           td Boolean
           td Permet l'upload de plusieurs fichiers
+        tr
+          td: code data:
+          td Hash
+          td Attributs data-* pour le champ
+        tr
+          td: code class:
+          td String
+          td Classes CSS additionnelles pour le champ
+        tr
+          td: code group_class:
+          td String
+          td Classes CSS additionnelles pour le groupe
 
 section.fr-my-4w id="hint"
   h2 Avec texte d'aide

--- a/docs/views/helpers/radio_buttons.slim
+++ b/docs/views/helpers/radio_buttons.slim
@@ -69,6 +69,14 @@ section.fr-my-4w id="options-disponibles"
           td: code rich:
           td Boolean
           td Active le style riche avec bordures
+        tr
+          td: code class:
+          td String
+          td Classes CSS additionnelles pour chaque bouton radio
+        tr
+          td: code fieldset_class:
+          td String
+          td Classes CSS additionnelles pour le fieldset
 
 section.fr-my-4w id="format-choix"
   h2 Format des choix

--- a/docs/views/helpers/select.slim
+++ b/docs/views/helpers/select.slim
@@ -102,6 +102,18 @@ section.fr-my-4w id="options-disponibles"
               td: code disabled:
               td Boolean
               td Désactive le champ entier
+            tr
+              td: code data:
+              td Hash
+              td Attributs data-* pour le select
+            tr
+              td: code class:
+              td String
+              td Classes CSS additionnelles pour le select
+            tr
+              td: code group_class:
+              td String
+              td Classes CSS additionnelles pour le groupe
 
     a href="https://api.rubyonrails.org/v8.0/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select" target="_blank"
       | Voir la documentation de `FormOptionsHelper#select`

--- a/docs/views/helpers/text_area.slim
+++ b/docs/views/helpers/text_area.slim
@@ -82,6 +82,18 @@ section.fr-my-4w id="options-disponibles"
           td: code disabled:
           td Boolean
           td Désactive le champ
+        tr
+          td: code data:
+          td Hash
+          td Attributs data-* pour le champ
+        tr
+          td: code class:
+          td String
+          td Classes CSS additionnelles pour le champ
+        tr
+          td: code group_class:
+          td String
+          td Classes CSS additionnelles pour le groupe
 
 section.fr-my-4w id="label-personnalise"
   h2 Avec un label personnalisé

--- a/docs/views/helpers/text_field.slim
+++ b/docs/views/helpers/text_field.slim
@@ -87,6 +87,10 @@ section.fr-my-4w id="options-disponibles"
         tr
           td: code class:
           td String
+          td Classes CSS additionnelles pour le champ
+        tr
+          td: code group_class:
+          td String
           td Classes CSS additionnelles pour le groupe
 
 section.fr-my-4w id="label-personnalise"

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -126,7 +126,7 @@ module Dsfr
         legend || @object.class.human_attribute_name(attribute),
         hint_tag(hint)
       ])
-      @template.tag.fieldset(class: "fr-fieldset") do
+      @template.tag.fieldset(class: @template.class_names("fr-fieldset", opts[:fieldset_class])) do
         @template.safe_join([
           @template.tag.legend(legend_content, class: "fr-fieldset__legend--regular fr-fieldset__legend"),
           choices.map do |choice|
@@ -136,7 +136,7 @@ module Dsfr
               label_text: choice[:label],
               hint: choice[:hint],
               checked: choice[:checked],
-              **opts
+              **opts.except(:fieldset_class)
             )
           end
         ])
@@ -148,7 +148,7 @@ module Dsfr
         @template.tag.div(class: @template.class_names("fr-radio-group", "fr-radio-rich" => rich)) do
           @template.safe_join([
             radio_button(attribute, value, checked:, **opts),
-            dsfr_label_with_hint(attribute, opts.merge(label_text: label_text, hint: hint, value: value))
+            dsfr_label_with_hint(attribute, opts.except(:class).merge(label_text: label_text, hint: hint, value: value))
           ])
         end
       end

--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -50,20 +50,20 @@ module Dsfr
     end
 
     def dsfr_input_field(attribute, input_kind, opts = {})
-      dsfr_input_group(attribute, **opts.except(:data)) do
+      dsfr_input_group(attribute, **opts.except(:data, :class, :group_class), class: opts[:group_class]) do
         @template.safe_join([
-          dsfr_label_with_hint(attribute, opts.except(:value)),
-          public_send(input_kind, attribute, class: "fr-input", **opts.except(:class, :hint, :label)),
+          dsfr_label_with_hint(attribute, opts.except(:value, :class)),
+          public_send(input_kind, attribute, class: @template.class_names("fr-input", opts[:class]), **opts.except(:class, :hint, :label, :group_class)),
           dsfr_error_message(attribute)
         ])
       end
     end
 
     def dsfr_file_field(attribute, opts = {})
-      dsfr_input_group(attribute, **opts, kind: :upload) do
+      dsfr_input_group(attribute, **opts.except(:data, :class, :group_class), class: opts[:group_class], kind: :upload) do
         @template.safe_join([
           dsfr_label_with_hint(attribute, opts.except(:class, :value)),
-          file_field(attribute, class: "fr-upload", **opts.except(:class, :hint, :label, :data)),
+          file_field(attribute, class: @template.class_names("fr-upload", opts[:class]), **opts.except(:class, :hint, :label, :data, :group_class)),
           dsfr_error_message(attribute)
         ])
       end
@@ -71,10 +71,10 @@ module Dsfr
 
     def dsfr_check_box(attribute, opts = {}, checked_value = "1", unchecked_value = "0")
       @template.tag.div(class: @template.class_names("fr-fieldset__element", "fr-fieldset__element--inline" => opts.delete(:inline))) do
-        dsfr_input_group(attribute, **opts, kind: :checkbox) do
+        dsfr_input_group(attribute, **opts.except(:data, :class, :group_class), class: opts[:group_class], kind: :checkbox) do
           @template.safe_join([
-            check_box(attribute, opts.except(:label, :hint), checked_value, unchecked_value),
-            dsfr_label_with_hint(attribute, opts)
+            check_box(attribute, opts.except(:label, :hint, :group_class), checked_value, unchecked_value),
+            dsfr_label_with_hint(attribute, opts.except(:class))
           ])
         end
       end
@@ -110,11 +110,11 @@ module Dsfr
     end
 
     def dsfr_select(attribute, choices, input_options = {}, **html_options)
-      select_html_options = html_options.dup.except(:hint, :name)
+      select_html_options = html_options.dup.except(:hint, :name, :label, :group_class)
       select_html_options[:class] = @template.class_names("fr-select", select_html_options[:class])
-      dsfr_input_group(attribute, **html_options, kind: :select) do
+      dsfr_input_group(attribute, **html_options.except(:data, :class, :group_class), class: html_options[:group_class], kind: :select) do
         @template.safe_join([
-          dsfr_label_with_hint(attribute, html_options),
+          dsfr_label_with_hint(attribute, html_options.except(:class)),
           select(attribute, choices, input_options, **select_html_options),
           dsfr_error_message(attribute)
         ])

--- a/spec/dsfr-form_builder_spec.rb
+++ b/spec/dsfr-form_builder_spec.rb
@@ -141,6 +141,28 @@ RSpec.describe Dsfr::FormBuilder do
         HTML
       end
     end
+
+    context 'when class is passed' do
+      it 'sets class on the input' do
+        expect(builder.dsfr_text_field(:name, class: "extra-class")).to match_html(<<~HTML)
+          <div class="fr-input-group">
+            <label class="fr-label" for="record_name">Name</label>
+            <input class="fr-input extra-class" type="text" value="Jean Paul" name="record[name]" id="record_name" />
+          </div>
+        HTML
+      end
+    end
+
+    context 'when group_class is passed' do
+      it 'sets class on the input group' do
+        expect(builder.dsfr_text_field(:name, group_class: "fr-mt-2w")).to match_html(<<~HTML)
+          <div class="fr-input-group fr-mt-2w">
+            <label class="fr-label" for="record_name">Name</label>
+            <input class="fr-input" type="text" value="Jean Paul" name="record[name]" id="record_name" />
+          </div>
+        HTML
+      end
+    end
   end
 
   describe '#dsfr_text_area' do
@@ -158,6 +180,160 @@ RSpec.describe Dsfr::FormBuilder do
 
       it "doesn't raise" do
         expect { builder.dsfr_text_area(:name, label: "Label") }.not_to raise_error
+      end
+    end
+
+    context 'when class is passed' do
+      it 'sets class on the input' do
+        expect(builder.dsfr_text_area(:name, class: "extra-class")).to match_html(<<~HTML)
+          <div class="fr-input-group">
+            <label class="fr-label" for="record_name">Name</label>
+            <textarea class="fr-input extra-class" name="record[name]" id="record_name">Jean Paul</textarea>
+          </div>
+        HTML
+      end
+    end
+
+    context 'when group_class is passed' do
+      it 'sets class on the input group' do
+        expect(builder.dsfr_text_area(:name, group_class: "fr-mt-2w")).to match_html(<<~HTML)
+          <div class="fr-input-group fr-mt-2w">
+            <label class="fr-label" for="record_name">Name</label>
+            <textarea class="fr-input" name="record[name]" id="record_name">Jean Paul</textarea>
+          </div>
+        HTML
+      end
+    end
+  end
+
+  describe '#dsfr_email_field' do
+    it 'generates the correct HTML' do
+      expect(builder.dsfr_email_field(:name)).to match_html(<<~HTML)
+        <div class="fr-input-group">
+          <label class="fr-label" for="record_name">Name</label>
+          <input class="fr-input" type="email" value="Jean Paul" name="record[name]" id="record_name" />
+        </div>
+      HTML
+    end
+
+    context 'when class is passed' do
+      it 'sets class on the input' do
+        expect(builder.dsfr_email_field(:name, class: "extra-class")).to match_html(<<~HTML)
+          <div class="fr-input-group">
+            <label class="fr-label" for="record_name">Name</label>
+            <input class="fr-input extra-class" type="email" value="Jean Paul" name="record[name]" id="record_name" />
+          </div>
+        HTML
+      end
+    end
+
+    context 'when group_class is passed' do
+      it 'sets class on the input-group' do
+        expect(builder.dsfr_email_field(:name, group_class: "fr-mt-2w")).to match_html(<<~HTML)
+          <div class="fr-input-group fr-mt-2w">
+            <label class="fr-label" for="record_name">Name</label>
+            <input class="fr-input" type="email" value="Jean Paul" name="record[name]" id="record_name" />
+          </div>
+        HTML
+      end
+    end
+  end
+
+  describe '#dsfr_url_field' do
+    it 'generates the correct HTML' do
+      expect(builder.dsfr_url_field(:name)).to match_html(<<~HTML)
+        <div class="fr-input-group">
+          <label class="fr-label" for="record_name">Name</label>
+          <input class="fr-input" type="url" value="Jean Paul" name="record[name]" id="record_name" />
+        </div>
+      HTML
+    end
+
+    context 'when class is passed' do
+      it 'sets class on the input' do
+        expect(builder.dsfr_url_field(:name, class: "extra-class")).to match_html(<<~HTML)
+          <div class="fr-input-group">
+            <label class="fr-label" for="record_name">Name</label>
+            <input class="fr-input extra-class" type="url" value="Jean Paul" name="record[name]" id="record_name" />
+          </div>
+        HTML
+      end
+    end
+
+    context 'when group_class is passed' do
+      it 'sets class on the input group' do
+        expect(builder.dsfr_url_field(:name, group_class: "fr-mt-2w")).to match_html(<<~HTML)
+          <div class="fr-input-group fr-mt-2w">
+            <label class="fr-label" for="record_name">Name</label>
+            <input class="fr-input" type="url" value="Jean Paul" name="record[name]" id="record_name" />
+          </div>
+        HTML
+      end
+    end
+  end
+
+  describe '#dsfr_phone_field' do
+    it 'generates the correct HTML' do
+      expect(builder.dsfr_phone_field(:name)).to match_html(<<~HTML)
+        <div class="fr-input-group">
+          <label class="fr-label" for="record_name">Name</label>
+          <input class="fr-input" type="tel" value="Jean Paul" name="record[name]" id="record_name" />
+        </div>
+      HTML
+    end
+
+    context 'when class is passed' do
+      it 'sets class on the input' do
+        expect(builder.dsfr_phone_field(:name, class: "extra-class")).to match_html(<<~HTML)
+          <div class="fr-input-group">
+            <label class="fr-label" for="record_name">Name</label>
+            <input class="fr-input extra-class" type="tel" value="Jean Paul" name="record[name]" id="record_name" />
+          </div>
+        HTML
+      end
+    end
+
+    context 'when group_class is passed' do
+      it 'sets class on the input group' do
+        expect(builder.dsfr_phone_field(:name, group_class: "fr-mt-2w")).to match_html(<<~HTML)
+          <div class="fr-input-group fr-mt-2w">
+            <label class="fr-label" for="record_name">Name</label>
+            <input class="fr-input" type="tel" value="Jean Paul" name="record[name]" id="record_name" />
+          </div>
+        HTML
+      end
+    end
+  end
+
+  describe '#dsfr_number_field' do
+    it 'generates the correct HTML' do
+      expect(builder.dsfr_number_field(:name)).to match_html(<<~HTML)
+        <div class="fr-input-group">
+          <label class="fr-label" for="record_name">Name</label>
+          <input class="fr-input" type="number" value="Jean Paul" name="record[name]" id="record_name" />
+        </div>
+      HTML
+    end
+
+    context 'when class is passed' do
+      it 'sets class on the input' do
+        expect(builder.dsfr_number_field(:name, class: "extra-class")).to match_html(<<~HTML)
+          <div class="fr-input-group">
+            <label class="fr-label" for="record_name">Name</label>
+            <input class="fr-input extra-class" type="number" value="Jean Paul" name="record[name]" id="record_name" />
+          </div>
+        HTML
+      end
+    end
+
+    context 'when group_class is passed' do
+      it 'sets class on the input group' do
+        expect(builder.dsfr_number_field(:name, group_class: "fr-mt-2w")).to match_html(<<~HTML)
+          <div class="fr-input-group fr-mt-2w">
+            <label class="fr-label" for="record_name">Name</label>
+            <input class="fr-input" type="number" value="Jean Paul" name="record[name]" id="record_name" />
+          </div>
+        HTML
       end
     end
   end
@@ -206,6 +382,28 @@ RSpec.describe Dsfr::FormBuilder do
 
       it "doesn't raise" do
         expect { builder.dsfr_file_field(:name, label: "Label") }.not_to raise_error
+      end
+    end
+
+    context 'when class is passed' do
+      it 'sets class on the input' do
+        expect(builder.dsfr_file_field(:name, class: "extra-class")).to match_html(<<~HTML)
+          <div class="fr-upload-group">
+            <label class="fr-label" for="record_name">Name</label>
+            <input class="fr-upload extra-class" type="file" name="record[name]" id="record_name" />
+          </div>
+        HTML
+      end
+    end
+
+    context 'when group_class is passed' do
+      it 'sets class on the upload group' do
+        expect(builder.dsfr_file_field(:name, group_class: "fr-mt-2w")).to match_html(<<~HTML)
+          <div class="fr-upload-group fr-mt-2w">
+            <label class="fr-label" for="record_name">Name</label>
+            <input class="fr-upload" type="file" name="record[name]" id="record_name" />
+          </div>
+        HTML
       end
     end
   end
@@ -327,6 +525,36 @@ RSpec.describe Dsfr::FormBuilder do
     #     </div>
     #   HTML
     # end
+
+    context 'when class is passed' do
+      it 'sets class on the select' do
+        expect(builder.dsfr_select(:role, choices, {}, class: "extra-class")).to match_html(<<~HTML)
+          <div class="fr-select-group">
+            <label class="fr-label" for="record_role">Role</label>
+            <select class="fr-select extra-class" name="record[role]" id="record_role">
+              <option value="admin">Administrateur</option>
+              <option value="editor">Éditeur</option>
+              <option value="reader">Lecteur</option>
+            </select>
+          </div>
+        HTML
+      end
+    end
+
+    context 'when group_class is passed' do
+      it 'sets class on the select group' do
+        expect(builder.dsfr_select(:role, choices, {}, group_class: "fr-mt-2w")).to match_html(<<~HTML)
+          <div class="fr-select-group fr-mt-2w">
+            <label class="fr-label" for="record_role">Role</label>
+            <select class="fr-select" name="record[role]" id="record_role">
+              <option value="admin">Administrateur</option>
+              <option value="editor">Éditeur</option>
+              <option value="reader">Lecteur</option>
+            </select>
+          </div>
+        HTML
+      end
+    end
   end
 
   describe "#dsfr_check_box" do
@@ -366,6 +594,34 @@ RSpec.describe Dsfr::FormBuilder do
 
       it "doesn't raise" do
         expect { builder.dsfr_check_box(:name, label: "Label") }.not_to raise_error
+      end
+    end
+
+    context 'when class is passed' do
+      it 'sets class on the input checkbox' do
+        expect(builder.dsfr_check_box(:name, class: "extra-class")).to match_html(<<~HTML)
+          <div class="fr-fieldset__element">
+            <div class="fr-checkbox-group">
+              <input name="record[name]" type="hidden" value="0" autocomplete="off">
+              <input class="extra-class" type="checkbox" value="1" name="record[name]" id="record_name" />
+              <label class="fr-label" for="record_name">Name</label>
+            </div>
+          </div>
+        HTML
+      end
+    end
+
+    context 'when group_class is passed' do
+      it 'sets class on the checkbox-group' do
+        expect(builder.dsfr_check_box(:name, group_class: "fr-mt-2w")).to match_html(<<~HTML)
+          <div class="fr-fieldset__element">
+            <div class="fr-checkbox-group fr-mt-2w">
+              <input name="record[name]" type="hidden" value="0" autocomplete="off">
+              <input type="checkbox" value="1" name="record[name]" id="record_name" />
+              <label class="fr-label" for="record_name">Name</label>
+            </div>
+          </div>
+        HTML
       end
     end
   end

--- a/spec/dsfr-form_builder_spec.rb
+++ b/spec/dsfr-form_builder_spec.rb
@@ -802,5 +802,45 @@ RSpec.describe Dsfr::FormBuilder do
         expect { builder.dsfr_radio_buttons(:pronom, choices, legend: "Legend", label_text: "Label") }.not_to raise_error
       end
     end
+
+    context 'when class is passed' do
+      it 'sets class on each radio input but not the labels' do
+        simple_choices = [ { value: "elle", label: "Elle" }, { value: "il", label: "Il" } ]
+        expect(builder.dsfr_radio_buttons(:pronom, simple_choices, legend: "Pronom", class: "extra-class")).to match_html(<<~HTML)
+          <fieldset class="fr-fieldset">
+            <legend class="fr-fieldset__legend--regular fr-fieldset__legend">Pronom</legend>
+            <div class="fr-fieldset__element">
+              <div class="fr-radio-group">
+                <input class="extra-class" type="radio" value="elle" name="record[pronom]" id="record_pronom_elle">
+                <label class="fr-label" for="record_pronom_elle">Elle</label>
+              </div>
+            </div>
+            <div class="fr-fieldset__element">
+              <div class="fr-radio-group">
+                <input class="extra-class" type="radio" value="il" name="record[pronom]" id="record_pronom_il">
+                <label class="fr-label" for="record_pronom_il">Il</label>
+              </div>
+            </div>
+          </fieldset>
+        HTML
+      end
+    end
+
+    context 'when fieldset_class is passed' do
+      it 'sets class on the fieldset' do
+        simple_choices = [ { value: "elle", label: "Elle" } ]
+        expect(builder.dsfr_radio_buttons(:pronom, simple_choices, legend: "Pronom", fieldset_class: "extra-class")).to match_html(<<~HTML)
+          <fieldset class="fr-fieldset extra-class">
+            <legend class="fr-fieldset__legend--regular fr-fieldset__legend">Pronom</legend>
+            <div class="fr-fieldset__element">
+              <div class="fr-radio-group">
+                <input type="radio" value="elle" name="record[pronom]" id="record_pronom_elle">
+                <label class="fr-label" for="record_pronom_elle">Elle</label>
+              </div>
+            </div>
+          </fieldset>
+        HTML
+      end
+    end
   end
 end


### PR DESCRIPTION
Le paramètre `class` permet de passer des classes CSS aux helpers. L’incohérence est qu’elles sont parfois transmises aux `<input>`, parfois aux `<div class="input-groups">` selon le helper. 

## Correction des params


| helper | avant | après |
| - | - | - |
dsfr_select | ✅ `class:` → `<select>` | `class:` → `<select>`<br>`group_class:` → `<div .fr-select-group>`
dsfr_check_box | ❌ `class:` → `<div .fr-checkbox-group>` et `<input>` | `class:` → `<input>`<br>`group_class:` → `<div .fr-checkbox-group>`
dsfr_file_field | ❌ `class:` → `<div .fr-upload-group>` | `class:` → `<input>`<br>`group_class:` → `<div .fr-upload-group>`
dsfr_radio_buttons | ❌  `class:` → `<input>` mais aussi sur `<label>` | `class:` → `<input>`<br>`fieldset_class:` → `<fieldset>`
dsfr_input_field<br>dsfr_text_field<br>dsfr_text_area<br>dsfr_email_field<br>dsfr_url_field<br>dsfr_phone_field<br>dsfr_number_field | ❌ `class:` → `<div .fr-input-group>` | `class:` -> `<input>`<br>`group_class:` → `<div .fr-input-group>`
dsfr_button<br>dsfr_submit | ✅ `class:` → `<input>` ou `<button>` | no changes
dsfr_collection_check_boxes | accepts `html_options[:class]` positional argument | no changes

## Correction label select

Au passage, on arrête de passer le kwarg `label:` au helper natif rails `select`, ce qui était une erreur car ça le mettait en attribut html du tag `<select>`.