### PR TITLE
Suppression du include ActiveSupport::Configurable

### DIFF
--- a/lib/dsfr-form_builder.rb
+++ b/lib/dsfr-form_builder.rb
@@ -1,6 +1,4 @@
 module Dsfr
-  include ActiveSupport::Configurable
-
   class FormBuilder < ActionView::Helpers::FormBuilder
     VERSION = "0.0.14"
 


### PR DESCRIPTION
Closes #75

Il me semble que nous n’utilisons pas Configurable.
Je propose donc de supprimer son include, pour supprimer le deprecation waring.